### PR TITLE
Fix connection signal signatures

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -83,8 +83,8 @@ signals:
 	void hostFound();
 	void connected();
 	void disconnected();
-	void stateChanged(SocketState);
-	void error(SocketError);
+	void stateChanged(Jreen::Connection::SocketState);
+	void error(Jreen::Connection::SocketError);
 
 protected:
 	virtual qint64 readData(char *data, qint64 maxlen) = 0;


### PR DESCRIPTION
Right now it's impossible to actually connect to these without your code being in the Jreen namespace, since you can't forward-declare enums before C++0x. Please accept this (and hopefully release again soon :-)  ).
