### PR TITLE
QtCore is called Qt5Core in pkg-config with Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ if(Qt5Core_DIR)
     find_package(Qt5Network QUIET)
     message(STATUS "Found Qt5!")
 
+    set(QT_VERSION_PC 5)
     add_definitions("-DQT_DISABLE_DEPRECATED_BEFORE=0")
     list(REMOVE_ITEM SRC "${CMAKE_CURRENT_SOURCE_DIR}/src/sjdns.cpp")
 else()

--- a/src/libjreen.pc.cmake
+++ b/src/libjreen.pc.cmake
@@ -5,7 +5,7 @@ includedir=${CMAKE_INSTALL_PREFIX}/include
 
 Name: libjreen
 Description: Qt Jabber/XMPP extensible library
-Requires: QtCore QtNetwork
+Requires: Qt${QT_VERSION_PC}Core Qt${QT_VERSION_PC}Network
 Version: ${CMAKE_JREEN_VERSION_MAJOR}.${CMAKE_JREEN_VERSION_MINOR}.${CMAKE_JREEN_VERSION_PATCH}
 Libs: -L${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX} -ljreen
 Cflags: -I${CMAKE_INSTALL_PREFIX}/include


### PR DESCRIPTION
QtCore references only Qt4
