### PR TITLE
Correct spelling mistakes

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -146,7 +146,7 @@ QString Error::conditionText() const
 		errorText = QCoreApplication::translate("Jreen::Error", "The stanza 'from' address specified by a connected client is not valid for the stream.");
 		break;
 	case Jreen::Error::Undefined:
-		errorText = QCoreApplication::translate("Jreen::Error", "No stanza error occured. You're just sleeping.");
+		errorText = QCoreApplication::translate("Jreen::Error", "No stanza error occurred. You're just sleeping.");
 		break;
 	}
 	return errorText;

--- a/src/error.h
+++ b/src/error.h
@@ -127,7 +127,7 @@ public:
 		* valid for the stream (e.g., the stanza does not include a 'from'
 		* address when multiple resources are bound to the stream); the
 		* associated error type SHOULD be "modify".*/
-		Undefined            /**< No stanza error occured. */
+		Undefined            /**< No stanza error occurred. */
 	};
 	//	enum Condition
 	//	{

--- a/src/registrationmanager.cpp
+++ b/src/registrationmanager.cpp
@@ -122,7 +122,7 @@ bool RegistrationData::hasFields() const
 void RegistrationData::setFieldValue(RegistrationData::FieldType type, const QString &value)
 {
 	if (d->values.size() <= type) {
-		jreenWarning() << "Unkown RegistrationData::ValueType:" << type;
+		jreenWarning() << "Unknown RegistrationData::ValueType:" << type;
 		return;
 	}
 	d->valuesFlags |= (1 << type);

--- a/src/vcard.h
+++ b/src/vcard.h
@@ -44,7 +44,7 @@ public:
 	* Addressing type indicators.
 	* @note @c AddrTypeDom and @c AddrTypeIntl are mutually exclusive. If both are present,
 	* @c AddrTypeDom takes precendence.
-	* @note Also note that not all adress types are applicable everywhere. For example,
+	* @note Also note that not all address types are applicable everywhere. For example,
 	* @c AddrTypeIsdn does not make sense for a postal address. Check XEP-0054
 	* for details.
 	*/


### PR DESCRIPTION
Hey, I'm packing libjreen for debian/ubuntu and while packing I found some spelling mistakes.

I've corrected them.