### PR TITLE
Fix build with Qt 5.6

### DIFF
--- a/src/stanzaextension.h
+++ b/src/stanzaextension.h
@@ -28,7 +28,7 @@
 
 #include <QObject>
 #include <QSharedPointer>
-#include <QMetaTypeId>
+#include <QMetaType>
 #include "jreen.h"
 
 class QXmlStreamWriter;


### PR DESCRIPTION
QMetaTypeId does not exist in Qt 5.6, causing a build failure.

Still builds fine against Qt 4.8 with this change.